### PR TITLE
Cache

### DIFF
--- a/_example/disableCache.go
+++ b/_example/disableCache.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	cbr "github.com/ivanglie/go-cbr-client"
+)
+
+func main() {
+	client := cbr.NewClient()
+
+	client.UseCache = false // disables cache for all requests
+
+	rate, err := client.GetRate("USD", time.Now())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(rate)
+}

--- a/cbr.go
+++ b/cbr.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 	"strings"
 	"time"
@@ -77,7 +76,7 @@ func getCurrencies(v *Result, t time.Time, fetch fetchFunction) error {
 	if err != nil {
 		return err
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/cbr.go
+++ b/cbr.go
@@ -22,6 +22,10 @@ const (
 // If this variable is set to true, debug mode activated for the package
 var Debug = false
 
+// Cache for requests
+var cache map[string]Result
+var cacheHits int
+
 // Currency is a currency item
 type Currency struct {
 	ID       string `xml:"ID,attr"`
@@ -39,16 +43,16 @@ type Result struct {
 	Currencies []Currency `xml:"Valute"`
 }
 
-func getRate(currency string, t time.Time, fetch fetchFunction) (float64, error) {
+func getRate(currency string, t time.Time, fetch fetchFunction, useCache bool) (float64, error) {
 	if Debug {
 		log.Printf("Fetching the currency rate for %s at %v\n", currency, t.Format("02.01.2006"))
 	}
 
-	var result Result
-	err := getCurrencies(&result, t, fetch)
+	result, err := getCurrenciesCacheOrRequest(t, fetch, useCache)
 	if err != nil {
 		return 0, err
 	}
+
 	for _, v := range result.Currencies {
 		if v.CharCode == currency {
 			return getCurrencyRateValue(v)
@@ -65,6 +69,33 @@ func getCurrencyRateValue(cur Currency) (float64, error) {
 		return res, err
 	}
 	return res / float64(cur.Nom), nil
+}
+
+func getCurrenciesCacheOrRequest(t time.Time, fetch fetchFunction, useCache bool) (Result, error) {
+	formatedDate := t.Format(dateFormat)
+
+	result := Result{}
+
+	// if currencies were already requested for this date - return from cache, if it is used
+	if cachedResult, exist := cache[formatedDate]; exist && useCache {
+		log.Printf("Get from cache!")
+		result = cachedResult
+		cacheHits += 1
+	} else {
+		err := getCurrencies(&result, t, fetch)
+		if err != nil {
+			return result, err
+		}
+		if useCache {
+			// if cache is used - put result to cache
+			if len(cache) == 0 {
+				// if cache is empty - initialize
+				cache = make(map[string]Result)
+			}
+			cache[formatedDate] = result
+		}
+	}
+	return result, nil
 }
 
 func getCurrencies(v *Result, t time.Time, fetch fetchFunction) error {

--- a/cbr_test.go
+++ b/cbr_test.go
@@ -1,6 +1,7 @@
 package cbr
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -9,16 +10,16 @@ import (
 
 func Test_Debug(t *testing.T) {
 	Debug = true
-	getRate("CNY", time.Now(), nil)
+	getRate("CNY", time.Now(), nil, false)
 	assert.True(t, Debug)
 
 	Debug = false
-	getRate("CNY", time.Now(), nil)
+	getRate("CNY", time.Now(), nil, false)
 	assert.False(t, Debug)
 }
 
 func Test_getRate_Error(t *testing.T) {
-	rate, err := getRate("CNY", time.Now(), nil)
+	rate, err := getRate("CNY", time.Now(), nil, false)
 	assert.NotNil(t, err)
 	assert.Equal(t, float64(0), rate)
 }
@@ -29,4 +30,118 @@ func Test_getCurrencyRateValue_Error(t *testing.T) {
 	rate, err := getCurrencyRateValue(c)
 	assert.NotNil(t, err)
 	assert.Equal(t, float64(0), rate)
+}
+
+// Check for the cache functionality
+func Test_getRate_Cache(t *testing.T) {
+	Debug = true
+	loc, _ := time.LoadLocation("Europe/Moscow")
+	testDate := time.Date(2022, 12, 16, 1, 1, 1, 0, time.UTC).In(loc)
+	tmpHits := cacheHits
+
+	timingDate := time.Now()
+
+	// Get first request uncached
+	rate, err := getRate("USD", testDate, http.Get, true)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	prevTime := logElapsedTime(timingDate, timingDate)
+
+	// Get second request from cache
+	rate, err = getRate("EUR", testDate, http.Get, true)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	assert.Greater(t, cacheHits, tmpHits)
+	tmpHits = cacheHits
+	prevTime = logElapsedTime(timingDate, prevTime)
+
+	// Get third request from cache
+	rate, err = getRate("TMT", testDate, http.Get, true)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	assert.Greater(t, cacheHits, tmpHits)
+	tmpHits = cacheHits
+	cacheLen := len(cache)
+	prevTime = logElapsedTime(timingDate, prevTime)
+
+	// Get NOT from cache
+	testDate = time.Date(2022, 12, 25, 1, 1, 1, 0, time.UTC).In(loc)
+	rate, err = getRate("TMT", testDate, http.Get, true)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	assert.Equal(t, cacheHits, tmpHits)     // no hit to cache was made
+	assert.Greater(t, len(cache), cacheLen) // new item appeared in cache
+	tmpHits = cacheHits
+	cacheLen = len(cache)
+	prevTime = logElapsedTime(timingDate, prevTime)
+
+	// Get 4th FROM cache
+	rate, err = getRate("USD", testDate, http.Get, true)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	assert.Greater(t, cacheHits, tmpHits) // hit to cache was made
+	assert.Equal(t, len(cache), cacheLen) // new item does not appear in cache
+	_ = logElapsedTime(timingDate, prevTime)
+}
+
+// Check for the cache functionality
+func Test_getRate_CacheDisabled(t *testing.T) {
+	Debug = true
+	cache = make(map[string]Result)
+	loc, _ := time.LoadLocation("Europe/Moscow")
+	testDate := time.Date(2022, 12, 10, 1, 1, 1, 0, time.UTC).In(loc)
+	tmpHits := cacheHits
+
+	timingDate := time.Now()
+
+	// Get first request uncached
+	rate, err := getRate("USD", testDate, http.Get, false)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	prevTime := logElapsedTime(timingDate, timingDate)
+
+	// Get second request from cache (disabled)
+	rate, err = getRate("EUR", testDate, http.Get, false)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	assert.Equal(t, cacheHits, tmpHits)
+	tmpHits = cacheHits
+	prevTime = logElapsedTime(timingDate, prevTime)
+
+	// Get third request from cache (disabled)
+	rate, err = getRate("TMT", testDate, http.Get, false)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	assert.Equal(t, cacheHits, tmpHits)
+	tmpHits = cacheHits
+	cacheLen := len(cache)
+	prevTime = logElapsedTime(timingDate, prevTime)
+
+	// Get NOT from cache
+	testDate = time.Date(2022, 12, 20, 1, 1, 1, 0, time.UTC).In(loc)
+	rate, err = getRate("TMT", testDate, http.Get, false)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	assert.Equal(t, cacheHits, tmpHits)   // no hit to cache was made
+	assert.Equal(t, len(cache), cacheLen) // new item appeared in cache
+	tmpHits = cacheHits
+	cacheLen = len(cache)
+	prevTime = logElapsedTime(timingDate, prevTime)
+
+	// Get 4th FROM cache (disabled)
+	rate, err = getRate("USD", testDate, http.Get, false)
+	assert.Nil(t, err)
+	assert.NotEqual(t, float64(0), rate)
+	assert.Equal(t, cacheHits, tmpHits)   // hit to cache was made
+	assert.Equal(t, len(cache), cacheLen) // new item does not appear in cache
+	_ = logElapsedTime(timingDate, prevTime)
+}
+
+func logElapsedTime(start time.Time, prev time.Time) time.Time {
+	if start.Equal(prev) {
+		log.Printf("Elapsed: %v µs\n", time.Since(start).Microseconds())
+	} else {
+		log.Printf("Elapsed since previous %vµs, total %vµs\n", time.Since(prev).Microseconds(), time.Since(start).Microseconds())
+	}
+	return time.Now()
 }

--- a/client.go
+++ b/client.go
@@ -15,11 +15,12 @@ type Client interface {
 }
 
 type client struct {
-	fetch fetchFunction
+	fetch    fetchFunction
+	UseCache bool
 }
 
 func (s client) GetRate(currency string, t time.Time) (float64, error) {
-	rate, err := getRate(currency, t, s.fetch)
+	rate, err := getRate(currency, t, s.fetch, s.UseCache)
 	if err != nil {
 		return 0, err
 	}
@@ -32,5 +33,5 @@ func (s client) SetFetchFunction(f fetchFunction) {
 
 // NewClient creates a new rates service instance
 func NewClient() Client {
-	return client{http.Get}
+	return client{fetch: http.Get, UseCache: true}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -24,7 +24,7 @@ func TestGetRate_Error(t *testing.T) {
 }
 
 func TestSetFetchFunction(t *testing.T) {
-	c := client{nil}
+	c := client{nil, false}
 	c.SetFetchFunction(func(url string) (resp *http.Response, err error) { return http.Get(url) })
 	assert.Equal(t, reflect.Func, reflect.TypeOf(c.fetch).Kind())
 }


### PR DESCRIPTION
Enabled cache for CBR-requests:
* backward compatible
* limits the number of requests to the server
* Speedup up to 10000 times for cached items
```
=== RUN   Test_getRate_Cache
2023/01/04 07:58:19 Fetching the currency rate for USD at 16.12.2022
2023/01/04 07:58:20 Elapsed: 76674 µs
2023/01/04 07:58:20 Fetching the currency rate for EUR at 16.12.2022
2023/01/04 07:58:20 Get from cache!
2023/01/04 07:58:20 Elapsed since previous 28µs, total 76728µs
2023/01/04 07:58:20 Fetching the currency rate for TMT at 16.12.2022
2023/01/04 07:58:20 Get from cache!
2023/01/04 07:58:20 Elapsed since previous 57µs, total 76795µs
2023/01/04 07:58:20 Fetching the currency rate for TMT at 25.12.2022
2023/01/04 07:58:20 Elapsed since previous 19781µs, total 96587µs
2023/01/04 07:58:20 Fetching the currency rate for USD at 25.12.2022
2023/01/04 07:58:20 Get from cache!
2023/01/04 07:58:20 Elapsed since previous 49µs, total 96664µs
```